### PR TITLE
Add clear event in clear() method

### DIFF
--- a/src/js/datePicker/index.js
+++ b/src/js/datePicker/index.js
@@ -521,6 +521,8 @@ export default class datePicker extends EventEmitter {
         this._setVisibleDate(today);
         this.refresh();
 
+        this.emit('clear', this);
+
     }
 
     render() {


### PR DESCRIPTION
This PR adds a new event, 'clear', which is emitted at the end of the clear() method for the datepicker.